### PR TITLE
Updating v1 monero cryptonight tweaks, and less global read/writes

### DIFF
--- a/cpu-miner.c
+++ b/cpu-miner.c
@@ -58,7 +58,7 @@ extern "C"
 }
 #endif
 
-extern void cryptonight_hash(void* output, const void* input, size_t len, int variant);
+extern int cryptonight_hash(void* output, const void* input, size_t len, int variant);
 void parse_device_config(int device, char *config, int *blocks, int *threads);
 
 #ifdef __linux /* Linux specific policy and affinity management */
@@ -638,7 +638,11 @@ static bool submit_upstream_work(CURL *curl, struct work *work)
 		noncestr = bin2hex(((const unsigned char*)work->data) + 39, 4);
 		int variant = ((unsigned char*)work->data)[0] >= 7 ? ((unsigned char*)work->data)[0] - 6 : 0;
 		char hash[32];
-		cryptonight_hash((void *)hash, (const void *)work->data, 76, variant);
+		if (!cryptonight_hash((void *)hash, (const void *)work->data, 76, variant)) {
+			applog(LOG_ERR, "submit_upstream_work cryptonight_hash failed");
+			free(str);
+			return rc;
+		}
 		char *hashhex = bin2hex((const unsigned char *)hash, 32);
 		snprintf(s, sizeof(s),
 				 "{\"method\": \"submit\", \"params\": {\"id\": \"%s\", \"job_id\": \"%s\", \"nonce\": \"%s\", \"result\": \"%s\"}, \"id\":1}",
@@ -659,7 +663,11 @@ static bool submit_upstream_work(CURL *curl, struct work *work)
 		char *noncestr = bin2hex(((const unsigned char*)work->data) + 39, 4);
 		int variant = ((unsigned char*)work->data)[0] >= 7 ? ((unsigned char*)work->data)[0] - 6 : 0;
 		char hash[32];
-		cryptonight_hash((void *)hash, (const void *)work->data, 76, variant);
+		if (!cryptonight_hash((void *)hash, (const void *)work->data, 76, variant)) {
+			applog(LOG_ERR, "submit_upstream_work cryptonight_hash failed");
+			free(str);
+			return rc;
+		}
 		char *hashhex = bin2hex((const unsigned char *)hash, 32);
 		snprintf(s, sizeof(s),
 				 "{\"method\": \"submit\", \"params\": {\"id\": \"%s\", \"job_id\": \"%s\", \"nonce\": \"%s\", \"result\": \"%s\"}, \"id\":1}",

--- a/cryptonight.c
+++ b/cryptonight.c
@@ -21,15 +21,18 @@
 #define VARIANT1_1(p) \
   do if (variant > 0) \
   { \
-    uint8_t tmp = ((const uint8_t*)p)[11]; \
-    uint8_t tmp1 = (tmp>>4)&1, tmp2 = (tmp>>5)&1, tmp3 = tmp1^tmp2; \
-    uint8_t tmp0 = nonce_flag ? tmp3 : tmp1 + 1; \
-    ((uint8_t*)p)[11] = (tmp & 0xef) | (tmp0<<4); \
+    const uint8_t tmp = ((const uint8_t*)(p))[11]; \
+    static const uint32_t table = 0x75310; \
+    const uint8_t index = (((tmp >> 3) & 6) | (tmp & 1)) << 1; \
+    ((uint8_t*)(p))[11] = tmp ^ ((table >> index) & 0x30); \
   } while(0)
 
-#define VARIANT1_2(p) VARIANT1_1(p)
 #define VARIANT1_INIT() \
-  const uint8_t nonce_flag = variant > 0 ? ((const uint8_t*)input)[39] & 0x01 : 0
+  if (variant > 0 && len < 43) \
+  { \
+    return 0; \
+  } \
+  const uint64_t tweak1_2 = variant > 0 ? *((const uint64_t*) (((const uint8_t*)input) + 35)) ^ ctx->state.hs.w[24] : 0
 
 struct cryptonight_ctx {
     uint8_t long_state[MEMORY];
@@ -122,14 +125,14 @@ static void mul_sum_dst(const uint8_t* a, const uint8_t* b, const uint8_t* c, ui
     ((uint64_t*) dst)[0] += ((uint64_t*) c)[0];
 }
 
-static void mul_sum_xor_dst(const uint8_t* a, uint8_t* c, uint8_t* dst) {
+static void mul_sum_xor_dst(const uint8_t* a, uint8_t* c, uint8_t* dst, const int variant, const uint64_t tweak1_2) {
     uint64_t hi, lo = mul128(((uint64_t*) a)[0], ((uint64_t*) dst)[0], &hi) + ((uint64_t*) c)[1];
     hi += ((uint64_t*) c)[0];
 
     ((uint64_t*) c)[0] = ((uint64_t*) dst)[0] ^ hi;
     ((uint64_t*) c)[1] = ((uint64_t*) dst)[1] ^ lo;
     ((uint64_t*) dst)[0] = hi;
-    ((uint64_t*) dst)[1] = lo;
+    ((uint64_t*) dst)[1] = variant > 0 ? lo ^ tweak1_2 : lo;
 }
 
 static void copy_block(uint8_t* dst, const uint8_t* src) {
@@ -147,7 +150,7 @@ static void xor_blocks_dst(const uint8_t* a, const uint8_t* b, uint8_t* dst) {
     ((uint64_t*) dst)[1] = ((uint64_t*) a)[1] ^ ((uint64_t*) b)[1];
 }
 
-void cryptonight_hash_ctx(void* output, const void* input, size_t len, struct cryptonight_ctx* ctx, int variant) {
+int cryptonight_hash_ctx(void* output, const void* input, size_t len, struct cryptonight_ctx* ctx, int variant) {
     size_t i, j;
     hash_process(&ctx->state.hs, (const uint8_t*) input, len);
     ctx->aes_ctx = (oaes_ctx*) oaes_alloc();
@@ -179,16 +182,14 @@ void cryptonight_hash_ctx(void* output, const void* input, size_t len, struct cr
         xor_blocks_dst(ctx->c, ctx->b, &ctx->long_state[j]);
         VARIANT1_1(&ctx->long_state[j]);
 
-        mul_sum_xor_dst(ctx->c, ctx->a, &ctx->long_state[e2i(ctx->c) * AES_BLOCK_SIZE]);
-        VARIANT1_2(&ctx->long_state[e2i(ctx->c) * AES_BLOCK_SIZE]);
+        mul_sum_xor_dst(ctx->c, ctx->a, &ctx->long_state[e2i(ctx->c) * AES_BLOCK_SIZE], variant, tweak1_2);
 
         j = e2i(ctx->a) * AES_BLOCK_SIZE;
         aesb_single_round(&ctx->long_state[j], ctx->b, ctx->a);
         xor_blocks_dst(ctx->b, ctx->c, &ctx->long_state[j]);
         VARIANT1_1(&ctx->long_state[j]);
 
-        mul_sum_xor_dst(ctx->b, ctx->a, &ctx->long_state[e2i(ctx->b) * AES_BLOCK_SIZE]);
-        VARIANT1_2(&ctx->long_state[e2i(ctx->b) * AES_BLOCK_SIZE]);
+        mul_sum_xor_dst(ctx->b, ctx->a, &ctx->long_state[e2i(ctx->b) * AES_BLOCK_SIZE], variant, tweak1_2);
     }
 
     memcpy(ctx->text, ctx->state.init, INIT_SIZE_BYTE);
@@ -210,10 +211,12 @@ void cryptonight_hash_ctx(void* output, const void* input, size_t len, struct cr
     hash_permutation(&ctx->state.hs);
     extra_hashes[ctx->state.hs.b[0] & 3](&ctx->state, 200, output);
     oaes_free((OAES_CTX **) &ctx->aes_ctx);
+    return 1;
 }
 
-void cryptonight_hash(void* output, const void* input, size_t len, int variant) {
+int cryptonight_hash(void* output, const void* input, size_t len, int variant) {
     struct cryptonight_ctx *ctx = (struct cryptonight_ctx*)malloc(sizeof(struct cryptonight_ctx));
-    cryptonight_hash_ctx(output, input, len, ctx, variant);
+    int rc = cryptonight_hash_ctx(output, input, len, ctx, variant);
     free(ctx);
+    return rc;
 }

--- a/cryptonight.h
+++ b/cryptonight.h
@@ -159,9 +159,9 @@ static inline void exit_if_cudaerror(int thr_id, const char *file, int line)
 void hash_permutation(union hash_state *state);
 void hash_process(union hash_state *state, const uint8_t *buf, size_t count);
 
-void cryptonight_core_cpu_hash(int thr_id, int blocks, int threads, uint32_t *d_long_state, uint32_t *d_ctx_state, uint32_t *d_ctx_a, uint32_t *d_ctx_b, uint32_t *d_ctx_key1, uint32_t *d_ctx_key2, int variant, uint8_t nonce_flag);
+void cryptonight_core_cpu_hash(int thr_id, int blocks, int threads, uint32_t *d_long_state, uint32_t *d_ctx_state, uint32_t *d_ctx_a, uint32_t *d_ctx_b, uint32_t *d_ctx_key1, uint32_t *d_ctx_key2, int variant, uint32_t *d_ctx_tweak1_2);
 
 void cryptonight_extra_cpu_setData(int thr_id, const void *data, const void *pTargetIn);
 void cryptonight_extra_cpu_init(int thr_id);
-void cryptonight_extra_cpu_prepare(int thr_id, int threads, uint32_t startNonce, uint32_t *d_ctx_state, uint32_t *d_ctx_a, uint32_t *d_ctx_b, uint32_t *d_ctx_key1, uint32_t *d_ctx_key2);
+void cryptonight_extra_cpu_prepare(int thr_id, int threads, uint32_t startNonce, uint32_t *d_ctx_state, uint32_t *d_ctx_a, uint32_t *d_ctx_b, uint32_t *d_ctx_key1, uint32_t *d_ctx_key2, int variant, uint32_t *d_ctx_tweak1_2);
 void cryptonight_extra_cpu_final(int thr_id, int threads, uint32_t startNonce, uint32_t *nonce, uint32_t *d_ctx_state);

--- a/cryptonight/cryptonight.cu
+++ b/cryptonight/cryptonight.cu
@@ -171,13 +171,14 @@ static uint32_t *d_ctx_b[MAX_GPU];
 static uint32_t *d_ctx_key1[MAX_GPU];
 static uint32_t *d_ctx_key2[MAX_GPU];
 static uint32_t *d_ctx_text[MAX_GPU];
+static uint32_t *d_ctx_tweak1_2[MAX_GPU];
 
 extern bool opt_benchmark;
 extern bool stop_mining;
 extern volatile bool mining_has_stopped[MAX_GPU];
 
 
-extern "C" void cryptonight_hash(void* output, const void* input, size_t len, int variant);
+extern "C" int cryptonight_hash(void* output, const void* input, size_t len, int variant);
 
 extern "C" int scanhash_cryptonight(int thr_id, uint32_t *pdata, const uint32_t *ptarget, uint32_t max_nonce, unsigned long *hashes_done, uint32_t *results)
 {
@@ -229,6 +230,8 @@ extern "C" int scanhash_cryptonight(int thr_id, uint32_t *pdata, const uint32_t 
 		exit_if_cudaerror(thr_id, __FILE__, __LINE__);
 		cudaMalloc(&d_ctx_b[thr_id], 4 * sizeof(uint32_t) * throughput);
 		exit_if_cudaerror(thr_id, __FILE__, __LINE__);
+		cudaMalloc(&d_ctx_tweak1_2[thr_id], 2 * sizeof(uint32_t) * throughput);
+		exit_if_cudaerror(thr_id, __FILE__, __LINE__);
 
 		cryptonight_extra_cpu_init(thr_id);
 
@@ -241,8 +244,8 @@ extern "C" int scanhash_cryptonight(int thr_id, uint32_t *pdata, const uint32_t 
 	{
 		uint32_t foundNonce[2];
 
-		cryptonight_extra_cpu_prepare(thr_id, throughput, nonce, d_ctx_state[thr_id], d_ctx_a[thr_id], d_ctx_b[thr_id], d_ctx_key1[thr_id], d_ctx_key2[thr_id]);
-		cryptonight_core_cpu_hash(thr_id, cn_blocks, cn_threads, d_long_state[thr_id], d_ctx_state[thr_id], d_ctx_a[thr_id], d_ctx_b[thr_id], d_ctx_key1[thr_id], d_ctx_key2[thr_id], variant, nonce);
+		cryptonight_extra_cpu_prepare(thr_id, throughput, nonce, d_ctx_state[thr_id], d_ctx_a[thr_id], d_ctx_b[thr_id], d_ctx_key1[thr_id], d_ctx_key2[thr_id], variant, d_ctx_tweak1_2[thr_id]);
+		cryptonight_core_cpu_hash(thr_id, cn_blocks, cn_threads, d_long_state[thr_id], d_ctx_state[thr_id], d_ctx_a[thr_id], d_ctx_b[thr_id], d_ctx_key1[thr_id], d_ctx_key2[thr_id], variant, d_ctx_tweak1_2[thr_id]);
 		cryptonight_extra_cpu_final(thr_id, throughput, nonce, foundNonce, d_ctx_state[thr_id]);
 
 		if(stop_mining)
@@ -258,8 +261,8 @@ extern "C" int scanhash_cryptonight(int thr_id, uint32_t *pdata, const uint32_t 
 			memcpy(tempdata, pdata, 76);
 			uint32_t *tempnonceptr = (uint32_t*)(((char*)tempdata) + 39);
 			*tempnonceptr = foundNonce[0];
-			cryptonight_hash(vhash64, tempdata, 76, variant);
-			if((vhash64[7] <= Htarg) && fulltest(vhash64, ptarget))
+			const int rc = cryptonight_hash(vhash64, tempdata, 76, variant);
+			if(rc && (vhash64[7] <= Htarg) && fulltest(vhash64, ptarget))
 			{
 				res = 1;
 				if(opt_debug)
@@ -269,8 +272,8 @@ extern "C" int scanhash_cryptonight(int thr_id, uint32_t *pdata, const uint32_t 
 				if(foundNonce[1] < 0xffffffff)
 				{
 					*tempnonceptr = foundNonce[1];
-					cryptonight_hash(vhash64, tempdata, 76, variant);
-					if((vhash64[7] <= Htarg) && fulltest(vhash64, ptarget))
+					const int rc = cryptonight_hash(vhash64, tempdata, 76, variant);
+					if(rc && (vhash64[7] <= Htarg) && fulltest(vhash64, ptarget))
 					{
 						res++;
 						if(opt_debug)

--- a/miner.h
+++ b/miner.h
@@ -204,7 +204,7 @@ extern int scanhash_cryptonight(int thr_id, uint32_t *pdata,
 	const uint32_t *ptarget, uint32_t max_nonce,
 	unsigned long *hashes_done, uint32_t *results);
 
-extern void cryptonight_hash(void* output, const void* input, size_t len, int variant);
+extern int cryptonight_hash(void* output, const void* input, size_t len, int variant);
 
 struct thr_info {
 	int		id;


### PR DESCRIPTION
This patch has a few updates:
- A branchless version of the first tweak that is posted in the main PR for monero. 
- Removes two global reads/writes per thread per iteration in the inner loop. The reads/writes are now "batched" with the existing ones. Hopefully this will remove the 5% slowdown that was reported, although I have not done in any "speed" runs for comparison.
-  Nonce flag should have been wrong after the first nonce (per batch).
- Adds the second XOR tweak - which is partially seen on the monero PR. The changes I made recently were to do a 64-bit XOR over bytes [8...15] instead of just [8...11], and make the constant XOR value being used a combination of 64-bits from the input XORed with the remaining 64-bits of the keccak output. This makes it no longer user controllable.

I ran a test harness with some test outputs that I can provide if necessary. People watching this PR should notice the changes to the CPU version as well - its similar to the ones that will be provided to other CPU miners.